### PR TITLE
Refresh selected public work

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I build Python services and TypeScript applications, and I use AWS and Docker fo
 - [Boring Agent Memory](https://github.com/hskl18/boring-agent-memory) provides source-grounded BM25 recall over trusted local files, with redaction and deterministic retrieval checks.
 - [LLM Inference Acceleration Playground](https://github.com/hskl18/llm-inference-acceleration-playground) measures latency, throughput, KV cache usage, and serving tradeoffs for OpenAI-compatible endpoints.
 - [Agent Sandbox Eval](https://github.com/hskl18/agent-sandbox-eval) evaluates tool-using agents in reproducible Docker sandboxes with recorded trajectories, grading, replay, and reports.
-- [Agentic Post-Training Lab](https://github.com/hskl18/agentic-post-training-lab) turns agent trajectories into filtered SFT data, reward scores, toy optimization runs, and evaluation artifacts.
+- [C++ Relational Database](https://github.com/hskl18/SQL) implements a SQL-like DSL, tokenizer, expression evaluation, B+ tree indexes, and binary record persistence.
 - [CareerOS](https://github.com/hskl18/public-careeros) is a local-first recruiting workflow that uses bounded email evidence, review gates, and optional Gemma analysis.
 - [Mail Guard](https://github.com/hskl18/mail-guard) is an IoT mailbox monitoring prototype built with Next.js, MySQL, AWS S3, device APIs, and event notifications.
 


### PR DESCRIPTION
## Summary
- replace the retired mock post-training repository with the retained C++ relational database project
- keep the selected work list aligned with the current public portfolio

## Verification
- the SQL repository link returns HTTP 200
- `git diff --check` passes